### PR TITLE
Fix compilation on MacOS

### DIFF
--- a/devices/HumanControlBoard/CMakeLists.txt
+++ b/devices/HumanControlBoard/CMakeLists.txt
@@ -25,7 +25,8 @@ target_link_libraries(HumanControlBoard PUBLIC
     YARP::YARP_OS
     YARP::YARP_dev
     YARP::YARP_init
-    iDynTree::idyntree-model)
+    iDynTree::idyntree-model
+    iDynTree::idyntree-estimation)
 
 yarp_install(
     TARGETS HumanControlBoard

--- a/devices/HumanStateProvider/CMakeLists.txt
+++ b/devices/HumanStateProvider/CMakeLists.txt
@@ -19,7 +19,8 @@ yarp_add_plugin(HumanStateProvider
     HumanIKWorkerPool.h)
 
 target_include_directories(HumanStateProvider PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
 
 target_link_libraries(HumanStateProvider PUBLIC
     IHumanState


### PR DESCRIPTION
Fixing the compilation errors in `MacOS` described in https://github.com/robotology/human-dynamics-estimation/issues/89#issuecomment-460657193.